### PR TITLE
Client.review

### DIFF
--- a/AeroGearSync-DiffMatchPatch/DiffMatchPatchMessage.swift
+++ b/AeroGearSync-DiffMatchPatch/DiffMatchPatchMessage.swift
@@ -18,17 +18,24 @@
 import Foundation
 import AeroGearSync
 
-public class DiffMatchPatchMessage<E>:PatchMessage<DiffMatchPatchEdit>, Printable {
+public struct DiffMatchPatchMessage:PatchMessage, Printable {
+    public let documentId: String!
+    public let clientId: String!
+    public let edits: [DiffMatchPatchEdit]!
     
-    public override init() {
-        super.init()
+    public var description: String {
+        return "DiffMatchPatchMessage[documentId=\(documentId), clientId=\(clientId), edits=\(edits)]"
     }
     
-    public override init(id: String, clientId: String, edits: [DiffMatchPatchEdit]) {
-        super.init(id: id, clientId: clientId, edits: edits)
+    public init() {}
+    
+    public init(id: String, clientId: String, edits: [DiffMatchPatchEdit]) {
+        self.documentId = id
+        self.clientId = clientId
+        self.edits = edits
     }
     
-    override public func asJson() -> String {
+    public func asJson() -> String {
         // TODO: This should be solved on the server side.
         var str = "{\"msgType\":\"patch\",\"id\":\"" + documentId + "\",\"clientId\":\"" + clientId + "\""
         str += ",\"edits\":["
@@ -52,11 +59,11 @@ public class DiffMatchPatchMessage<E>:PatchMessage<DiffMatchPatchEdit>, Printabl
         return str
     }
     
-    override public func fromJson(var json:String) -> PatchMessage<DiffMatchPatchEdit>? {
+    public func fromJson(var json:String) -> DiffMatchPatchMessage? {
         if let dict = asDictionary(json) {
             let id = dict["id"] as String
             let clientId = dict["clientId"] as String
-            var edits = Array<DiffMatchPatchEdit>()
+            var edits = [DiffMatchPatchEdit]()
             for (key: String, jsonEdit) in dict["edits"] as [String: AnyObject] {
                 var diffs = Array<DiffMatchPatchDiff>()
                 for (key: String, jsonDiff) in jsonEdit["diffs"] as [String: AnyObject] {
@@ -70,7 +77,7 @@ public class DiffMatchPatchMessage<E>:PatchMessage<DiffMatchPatchEdit>, Printabl
                     checksum: jsonEdit["checksum"] as String,
                     diffs: diffs))
             }
-            return PatchMessage(id: id, clientId: clientId, edits: edits)
+            return DiffMatchPatchMessage(id: id, clientId: clientId, edits: edits)
         }
         return Optional.None
     }

--- a/AeroGearSync-DiffMatchPatch/DiffMatchPatchSynchronizer.swift
+++ b/AeroGearSync-DiffMatchPatch/DiffMatchPatchSynchronizer.swift
@@ -88,12 +88,12 @@ public class DiffMatchPatchSynchronizer: ClientSynchronizer {
         }
     }
     
-    public func patchMessageFromJson(json: String) -> PatchMessage<DiffMatchPatchEdit>? {
-        return DiffMatchPatchMessage<DiffMatchPatchEdit>().fromJson(json)
+    public func patchMessageFromJson(json: String) -> DiffMatchPatchMessage? {
+        return DiffMatchPatchMessage().fromJson(json)
     }
     
-    public func createPatchMessage(id: String, clientId: String, edits: [DiffMatchPatchEdit]) -> PatchMessage<DiffMatchPatchEdit>? {
-        return DiffMatchPatchMessage<DiffMatchPatchEdit>(id: id, clientId: clientId, edits: edits)
+    public func createPatchMessage(id: String, clientId: String, edits: [DiffMatchPatchEdit]) -> DiffMatchPatchMessage? {
+        return DiffMatchPatchMessage(id: id, clientId: clientId, edits: edits)
     }
     
     public func addContent(clientDocument:ClientDocument<String>, fieldName:String, inout objectNode:String) {

--- a/AeroGearSync-DiffMatchPatchTests/ClientSyncEngineTests.swift
+++ b/AeroGearSync-DiffMatchPatchTests/ClientSyncEngineTests.swift
@@ -49,7 +49,7 @@ class ClientSyncEngineTests: XCTestCase {
 
     func testDiff() {
         engine.addDocument(util.document("testing"), callback: emptyCallback)
-        let patchMessage: PatchMessage! = engine.diff(util.document("testing2"))
+        let patchMessage: DiffMatchPatchMessage! = engine.diff(util.document("testing2"))
         XCTAssertTrue(patchMessage != nil)
         XCTAssertEqual("1234" , patchMessage.documentId)
         XCTAssertEqual("client1" , patchMessage.clientId)
@@ -74,7 +74,7 @@ class ClientSyncEngineTests: XCTestCase {
             DiffMatchPatchDiff(operation: .Delete, text: "."),
             DiffMatchPatchDiff(operation: .Add, text: "!")]
         let edit = DiffMatchPatchEdit(clientId: doc.clientId, documentId: doc.id, clientVersion: 0, serverVersion: 0, checksum: "", diffs: diffs)
-        engine.patch(PatchMessage(id: doc.id, clientId: doc.clientId, edits: [edit]))
+        engine.patch(DiffMatchPatchMessage(id: doc.id, clientId: doc.clientId, edits: [edit]))
     }
 
     func testPatchMultipleEdits() {
@@ -90,7 +90,7 @@ class ClientSyncEngineTests: XCTestCase {
             diffs: [DiffMatchPatchDiff(operation: .Unchanged, text: "Do or do not, there is no try"),
                 DiffMatchPatchDiff(operation: .Delete, text: "!"),
                 DiffMatchPatchDiff(operation: .Add, text: "?")])
-        engine.patch(PatchMessage(id: doc.id, clientId: doc.clientId, edits: [edit1, edit2]))
+        engine.patch(DiffMatchPatchMessage(id: doc.id, clientId: doc.clientId, edits: [edit1, edit2]))
         XCTAssertTrue(dataStore.getEdits(doc.id, clientId: doc.clientId) == nil)
     }
 
@@ -116,8 +116,8 @@ class ClientSyncEngineTests: XCTestCase {
         diffs2.append(DiffMatchPatchDiff(operation: .Unchanged, text: "2"))
         let edit2 = DiffMatchPatchEdit(clientId: doc2.clientId, documentId: doc2.id, clientVersion: 0, serverVersion: 0, checksum: "", diffs: diffs2)
 
-        engine.patch(PatchMessage(id: doc1.id, clientId: doc1.clientId, edits: [edit1]))
-        engine.patch(PatchMessage(id: doc2.id, clientId: doc2.clientId, edits: [edit2]))
+        engine.patch(DiffMatchPatchMessage(id: doc1.id, clientId: doc1.clientId, edits: [edit1]))
+        engine.patch(DiffMatchPatchMessage(id: doc2.id, clientId: doc2.clientId, edits: [edit2]))
         XCTAssertTrue(dataStore.getEdits(doc1.id, clientId: doc1.clientId) == nil)
         XCTAssertTrue(dataStore.getEdits(doc2.id, clientId: doc2.clientId) == nil)
     }

--- a/AeroGearSync-JSONPatch/JsonPatchMessage.swift
+++ b/AeroGearSync-JSONPatch/JsonPatchMessage.swift
@@ -18,17 +18,24 @@
 import Foundation
 import AeroGearSync
 
-public class JsonPatchMessage<E>:PatchMessage<JsonPatchEdit>, Printable {
+public struct JsonPatchMessage: PatchMessage, Printable {
+    public let documentId: String!
+    public let clientId: String!
+    public let edits: [JsonPatchEdit]!
     
-    public override init() {
-        super.init()
+    public var description: String {
+        return "JsonPatchMessage[documentId=\(documentId), clientId=\(clientId), edits=\(edits)]"
     }
     
-    public override init(id: String, clientId: String, edits: [JsonPatchEdit]) {
-        super.init(id: id, clientId: clientId, edits: edits)
+    public init() {}
+    
+    public init(id: String, clientId: String, edits: [JsonPatchEdit]) {
+        self.documentId = id
+        self.clientId = clientId
+        self.edits = edits
     }
     
-    override public func asJson() -> String {
+    public func asJson() -> String {
         var str = "{\"msgType\":\"patch\",\"id\":\"" + documentId + "\",\"clientId\":\"" + clientId + "\""
         str += ",\"edits\":["
         let count = edits.count-1
@@ -67,7 +74,7 @@ public class JsonPatchMessage<E>:PatchMessage<JsonPatchEdit>, Printable {
         return str
     }
     
-    override public func fromJson(var json:String) -> PatchMessage<JsonPatchEdit>? {
+    public func fromJson(var json:String) -> JsonPatchMessage? {
         if let dict = asDictionary(json) {
             let id = dict["id"] as String
             let clientId = dict["clientId"] as String

--- a/AeroGearSync-JSONPatch/JsonPatchSynchronizer.swift
+++ b/AeroGearSync-JSONPatch/JsonPatchSynchronizer.swift
@@ -91,12 +91,12 @@ public class JsonPatchSynchronizer: ClientSynchronizer {
         return diffs.map { ["op": $0.operation.rawValue, "path": $0.path, "value": $0.value ?? ""] }
     }
     
-    public func patchMessageFromJson(json: String) -> PatchMessage<JsonPatchEdit>? {
-        return JsonPatchMessage<JsonPatchEdit>().fromJson(json)
+    public func patchMessageFromJson(json: String) -> JsonPatchMessage? {
+        return JsonPatchMessage().fromJson(json)
     }
     
-    public func createPatchMessage(id: String, clientId: String, edits: [JsonPatchEdit]) -> PatchMessage<JsonPatchEdit>? {
-        return JsonPatchMessage<JsonPatchEdit>(id: id, clientId: clientId, edits: edits)
+    public func createPatchMessage(id: String, clientId: String, edits: [JsonPatchEdit]) -> JsonPatchMessage? {
+        return JsonPatchMessage(id: id, clientId: clientId, edits: edits)
     }
     
     public func addContent(clientDocument:ClientDocument<JsonNode>, fieldName:String, inout objectNode:String) {

--- a/AeroGearSync/ClientSynchronizer.swift
+++ b/AeroGearSync/ClientSynchronizer.swift
@@ -21,6 +21,7 @@ public protocol ClientSynchronizer {
     
     typealias T
     typealias D: Edit
+    typealias P: PatchMessage
 
     func patchShadow(edit: D, shadow: ShadowDocument<T>) -> ShadowDocument<T>
     
@@ -30,9 +31,9 @@ public protocol ClientSynchronizer {
     
     func serverDiff(serverDocument: ClientDocument<T>, shadow: ShadowDocument<T>) -> D
     
-    func patchMessageFromJson(json: String) -> PatchMessage<D>?
+    func patchMessageFromJson(json: String) -> P?
 
-    func createPatchMessage(id: String, clientId: String, edits: [D]) -> PatchMessage<D>?
+    func createPatchMessage(id: String, clientId: String, edits: [D]) -> P?
     
     func addContent(content:ClientDocument<T>, fieldName:String, inout objectNode:String)
 }

--- a/AeroGearSync/PatchMesssage.swift
+++ b/AeroGearSync/PatchMesssage.swift
@@ -17,30 +17,13 @@
 
 import Foundation
 
-public class PatchMessage<E:Edit>: Printable, Payload {
+public protocol PatchMessage: Printable, Payload {
     
-    public let documentId: String!
-    public let clientId: String!
-    public let edits: [E]!
+    typealias E: Edit
     
-    public init() {}
+    var documentId: String! {get}
+    var clientId: String! {get}
+    var edits: [E]! {get}
     
-    public init(id: String, clientId: String, edits: [E]) {
-        self.documentId = id
-        self.clientId = clientId
-        self.edits = edits
-    }
-    
-    public func asJson() -> String {
-        fatalError("This method must be overridden")
-    }
-    
-    public func fromJson(var json:String) -> PatchMessage<E>? {
-        fatalError("This method must be overridden")
-    }
-    
-    public var description: String {
-        return "PatchMessage[documentId=\(documentId), clientId=\(clientId), edits=\(edits)]"
-    }
-    
+    init(id: String, clientId: String, edits: [E])    
 }


### PR DESCRIPTION
@cvasilak here is a proposal, i think having:
- PatchMessage as a protocol and using protocol constraints on ClientEngine instead of having a class with empty body
- leaving JsonPatchMessage and DiffMatchPatchMessage as struct implementing PatchMessage protocol
  makes it more the 'swift' way...
